### PR TITLE
Remove respectTransparency overrides

### DIFF
--- a/Experimental/AffineSpace/Convex/Star.lean
+++ b/Experimental/AffineSpace/Convex/Star.lean
@@ -378,7 +378,6 @@ lemma starConvex_compl_Iic (h : x < y) : StarConvex 𝕜 y (Iic x)ᶜ := by
       rw [add_smul, sub_lt_iff_lt_add']
       gcongr
 
-set_option backward.isDefEq.respectTransparency false in
 /-- If `x < y`, then `(Set.Ici y)ᶜ` is star convex at `x`. -/
 lemma starConvex_compl_Ici (h : x < y) : StarConvex 𝕜 x (Ici y)ᶜ :=
   starConvex_compl_Iic (E := Eᵒᵈ) h

--- a/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Basic.lean
+++ b/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Basic.lean
@@ -87,7 +87,6 @@ abbrev linSpan (C : PointedCone R M) : Submodule R M := span R C
 lemma ofSubmodule_linSpan (S : Submodule R M) :
   (S : PointedCone R M).linSpan = S := Submodule.span_eq _
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp] lemma linSpan_hull_eq_submodule_span (s : Set M) :
     span R (hull R s) = span R s := Submodule.span_span_of_tower ..
 
@@ -106,11 +105,9 @@ alias span_submodule_span := linSpan_hull_eq_submodule_span
 
 -- ## COE
 
-set_option backward.isDefEq.respectTransparency false in
 lemma coe_inf (S T : Submodule R M) : S ⊓ T = (S ⊓ T : PointedCone R M)
     := Submodule.restrictScalars_inf _ _ _
 
-set_option backward.isDefEq.respectTransparency false in
 lemma sInf_coe (s : Set (Submodule R M)) : sInf s = sInf (ofSubmodule '' s) :=
   Submodule.restrictScalars_sInf _ _
 
@@ -120,11 +117,9 @@ lemma iInf_coe (s : Set (Submodule R M)) : ⨅ S ∈ s, S = ⨅ S ∈ s, (S : Po
 -- lemma iInf_coe' (s : Set (Submodule R M)) : ⨅ S ∈ s, S = ⨅ S ∈ s, (S : PointedCone R M) := by
 --   rw [← sInf_eq_iInf, sInf_coe, sInf_eq_iInf]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma coe_sup (S T : Submodule R M) : S ⊔ T = (S ⊔ T : PointedCone R M)
     := Submodule.restrictScalars_sup _ _ _
 
-set_option backward.isDefEq.respectTransparency false in
 lemma sSup_coe (s : Set (Submodule R M)) : sSup s = sSup (ofSubmodule '' s) :=
   Submodule.restrictScalars_sSup _ _
 
@@ -152,7 +147,6 @@ lemma coe_sup_submodule_span {C D : PointedCone R M} :
   rw [← linSpan_hull_eq_submodule_span]
   simp [Submodule.span_union]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma hull_le_submodule_span (s : Set M) : hull R s ≤ Submodule.span R s :=
     Submodule.span_le_restrictScalars _ _ s
 
@@ -339,16 +333,19 @@ lemma restrict_fg_iff_inf_fg (S : Submodule R M) (C : PointedCone R M) :
 lemma restrict_mono (S : Submodule R M) {C D : PointedCone R M} (hCD : C ≤ D) :
     C.restrict S ≤ D.restrict S := fun _ => (hCD ·)
 
-set_option backward.isDefEq.respectTransparency false in
 lemma restrict_inf (S : Submodule R M) {C D : PointedCone R M} :
     (C ⊓ D).restrict S = C.restrict S ⊓ D.restrict S
-  := by ext x; simp [restrict, Submodule.submoduleOf]
+  := by
+  ext x
+  rw [mem_restrict_iff]
+  constructor <;> exact fun hx ↦ ⟨hx.1, hx.2⟩
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma restrict_inf_submodule (S : Submodule R M) (C : PointedCone R M) :
     (C ⊓ S).restrict S = C.restrict S := by
-  simp [restrict_inf, Submodule.restrict_self]
+  ext x
+  rw [mem_restrict_iff, mem_restrict_iff]
+  exact and_iff_left x.property
 
 @[simp]
 lemma restrict_submodule_inf (S : Submodule R M) (C : PointedCone R M) :
@@ -520,7 +517,6 @@ variable (R) in
 -- NOTE: if this is implemented, it is more general than what mathlib already provides
 -- for converting submodules into pointed cones. Especially the proof that R≥0 is an FG
 -- submodule of R should be easier with this.
-set_option backward.isDefEq.respectTransparency false in
 @[simp] lemma hull_union_neg_eq_submodule_span (s : Set M) :
     hull R (-s ∪ s) = span R s := by
   ext x
@@ -691,16 +687,13 @@ lemma quot_fg (hC : C.FG) (S : Submodule R M) : (C.quot S).FG := hC.map _
     (C ⊔ S).quot S = C.quot S := sorry
 
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma quot_eq_iff_sup_eq {S : Submodule R M} {C D : PointedCone R M} :
     C.quot S = D.quot S ↔ C ⊔ S = D ⊔ S := Submodule.map_mkQ_eq_iff_sup_eq
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp] lemma map_mkQ_le_iff_sup_le {p : Submodule R M} {s t : PointedCone R M} :
     map p.mkQ s ≤ map p.mkQ t ↔ s ⊔ p ≤ t ⊔ p := Submodule.map_mkQ_le_iff_sup_le
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp] lemma map_mkQ_eq_iff_sup_eq {p : Submodule R M} {s t : PointedCone R M} :
     map p.mkQ s = map p.mkQ t ↔ s ⊔ p = t ⊔ p := Submodule.map_mkQ_eq_iff_sup_eq
 
@@ -711,7 +704,6 @@ variable {R M : Type*} [CommRing R] [PartialOrder R] [IsOrderedRing R] [AddCommG
 
 local notation "R≥0" => {c : R // 0 ≤ c}
 
-set_option backward.isDefEq.respectTransparency false in
 noncomputable def IsCompl.map_mkQ_equiv_inf {S T : Submodule R M} (hST : IsCompl S T)
     {C : PointedCone R M} (hSC : S ≤ C) : C.quot S ≃ₗ[R≥0] (C ⊓ T : PointedCone R M) :=
   Submodule.IsCompl.map_mkQ_equiv_inf hST hSC

--- a/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Dual.lean
+++ b/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Dual.lean
@@ -286,11 +286,11 @@ lemma dual_embed_quot_dual (S : Submodule R M) (C : PointedCone R S) :
       simpa only [rp_apply] using h
     · rw [surjInv_eq (Submodule.dual p S).mkQ_surjective]
 
-set_option backward.isDefEq.respectTransparency false in
 variable (p) in
 lemma dual_quot_dual (S : Submodule R M) (C : PointedCone R M) :
     (dual p (S ∩ C)).quot (.dual p S) = dual (p.rp S) (restrict S C) := by
-  simp only [← coe_ofSubmodule S, ← Submodule.coe_inf, ← embed_restrict S C, ← dual_embed_quot_dual]
+  simpa only [embed_restrict, ← coe_ofSubmodule S, ← Submodule.coe_inf] using
+    dual_embed_quot_dual p S (restrict S C)
 
 alias dual_restrict := dual_quot_dual
 
@@ -304,7 +304,6 @@ alias dual_restrict_of_le := dual_quot_dual_of_le
 
 local notation "R≥0" => {c : R // 0 ≤ c}
 
-set_option backward.isDefEq.respectTransparency false in
 variable (p) in
 lemma comap_dual_mkQ_dual (S : Submodule R M) (C : PointedCone R S) :
     comap (Submodule.dual p S).mkQ (dual (p.rp S) C) = dual p (embed C) := by

--- a/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Face/Basic.lean
+++ b/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Face/Basic.lean
@@ -557,7 +557,6 @@ lemma hull_nonneg_lc_mem {ι : Type*} [Fintype ι] {c : ι → R} (hcc : ∀ i, 
 
 variable {s t : Set M}
 
-set_option backward.isDefEq.respectTransparency false in
 lemma hull_inter_face_hull_inf_face (hF : F.IsFaceOf (hull R s)) :
     hull R (s ∩ F) = F := by
   ext x; constructor
@@ -608,7 +607,6 @@ variable {C F : PointedCone R M}
 
 -- ## QUOT / FIBER
 
-set_option backward.isDefEq.respectTransparency false in
 lemma quot {S : Submodule R M} (hF : F.IsFaceOf C) (hS : S ≤ span R F) :
     (F.quot S).IsFaceOf (C.quot S) := by
   refine ⟨map_mono hF.le, ?_⟩

--- a/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Face/Lattice.lean
+++ b/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Face/Lattice.lean
@@ -394,7 +394,6 @@ lemma bot_face {F : Face C} (hC : C.Salient) : F.toPointedCone = ⊥ ↔ F = ⊥
   change x ∈ F.toPointedCone ↔ x ∈ (⊥ : Face C).toPointedCone
   simp [h, hbotcone]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma fiberFace_eq_iff {F : Face C} (G : Face (C ⧸ F)) :
     F = fiberFace G ↔ G.toPointedCone = ⊥ := by
   constructor <;> intro h

--- a/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Finite/Basic.lean
+++ b/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Finite/Basic.lean
@@ -12,19 +12,16 @@ section LinearOrderRing
 variable {R M : Type*} [Ring R] [LinearOrder R] [IsOrderedRing R] [AddCommMonoid M]
   [Module R M]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma coe_fg {S : Submodule R M} (hS : S.FG) : (S : PointedCone R M).FG
     := Submodule.FG.restrictScalars hS
 
 -- Q: is this problematic?
 -- instance {S : Submodule R M} : Coe S.FG (S : PointedCone R M).FG := ⟨coe_fg⟩
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 lemma coe_fg_iff {S : Submodule R M} : (S : PointedCone R M).FG ↔ S.FG :=
   ⟨Submodule.FG.of_restrictScalars _, coe_fg⟩
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The submodule span of a finitely generated pointed cone is finitely generated. -/
 lemma span_fg {C : PointedCone R M} (hC : C.FG) : (span R (C : Set M)).FG := hC.span
 

--- a/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Finite/Face/Basic.lean
+++ b/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Finite/Face/Basic.lean
@@ -91,7 +91,6 @@ variable {R : Type*} [DivisionRing R] [LinearOrder R] [IsOrderedRing R]
 variable {M : Type*} [AddCommGroup M] [Module R M]
 variable {C : PointedCone R M}
 
-set_option backward.isDefEq.respectTransparency false in
 open Submodule in
 /-- If a point `x` does not lie in a cone `C` but together with `C` spans a salient cone, then
   `x` spans a face of `hull R (C ∪ {x})`. -/

--- a/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Finite/MinkowskiWeyl.lean
+++ b/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Finite/MinkowskiWeyl.lean
@@ -215,7 +215,6 @@ lemma FG.exists_dualfg_inf_span {C : PointedCone 𝕜 N} (hC : C.FG) :
 --   · rw [dual_sup_dual_inf_dual]
 --     simp [Submodule.FG.dual_dual_flip _ hS] -- <-- submodule duality theory
 
-set_option backward.isDefEq.respectTransparency false in
 variable (p) [Fact p.SeparatingRight] in
 /-- An FG cone is the dual of a DualFG cone. -/
 lemma FG.exists_dualfg_dual {C : PointedCone 𝕜 N} (hC : C.FG) :
@@ -327,7 +326,6 @@ lemma fg_iff_dualfg {C : PointedCone 𝕜 N} : C.FG ↔ C.DualFG p := ⟨FG.dual
 -- /-- A finite dimensional cone is FG if and only if it is DualFG. -/
 -- lemma fg_iff_dualfg {C : PointedCone 𝕜 N} : C.DualFG p ↔ C.FG := ⟨FGDual.fg, FG.dualfg p⟩
 
-set_option backward.isDefEq.respectTransparency false in
 variable (p) in
 /-- In finite dimensional space, the dual of and FG cone is itself FG. -/
 lemma FG.dual_fg {C : PointedCone 𝕜 M} (hC : C.FG) : (dual p C).FG := by

--- a/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Lineal.lean
+++ b/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Lineal.lean
@@ -366,7 +366,6 @@ variable {R : Type*} [Ring R] [PartialOrder R] [IsOrderedRing R]
 variable {M : Type*} [AddCommGroup M] [Module R M]
 
 -- NOTE: an easier proof via `salient_of_pos_linearMap` seems only possible if `R` is a field.
-set_option backward.isDefEq.respectTransparency false in
 lemma Salient.of_hull_linearIndepOn {s : Set M} (h : LinearIndepOn R id s) :
     (hull R s).Salient := by classical
   -- next line needs fixing once ConvexCone is removed

--- a/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Rank.lean
+++ b/Polyhedral/Mathlib/Geometry/Convex/Cone/Pointed/Rank.lean
@@ -28,7 +28,6 @@ abbrev FinRank (C : PointedCone R M) := (span R (C : Set M)).FG
 @[simp] lemma finRank_of_isNoetherian [IsNoetherian R M] (C : PointedCone R M) : C.FinRank :=
   IsNoetherian.noetherian (span R (C : Set M))
 
-set_option backward.isDefEq.respectTransparency false in
 lemma FG.finRank {C : PointedCone R M} (hC : C.FG) : C.FinRank := hC.span
 
 alias finRank_of_fg := FG.finRank

--- a/Polyhedral/Polyhedral/Basic.lean
+++ b/Polyhedral/Polyhedral/Basic.lean
@@ -60,7 +60,6 @@ lemma IsPolyhedral.of_hull_finite {s : Set M} (hs : s.Finite) : (hull R s).IsPol
 lemma isPolyhedral_of_hull_finset (s : Finset M) : (hull (E := M) R s).IsPolyhedral :=
   .of_hull_finite s.finite_toSet
 
-set_option backward.isDefEq.respectTransparency false in
 /- If the quotient by any contained submodule is FG, then the cone is polyhedral. -/
 lemma IsPolyhedral.of_quot_fg {S : Submodule R M} (hS : S ≤ C) (hC : FG (C.quot S)) :
     C.IsPolyhedral := by
@@ -164,7 +163,6 @@ lemma IsPolyhedral.sup_fg (hC : C.IsPolyhedral) {D : PointedCone R M} (hD : D.FG
 
 -- ## MAP / COMAP
 
-set_option backward.isDefEq.respectTransparency false in
 lemma IsPolyhedral.map (hC : C.IsPolyhedral) (f : M →ₗ[R] N) : (C.map f).IsPolyhedral := by
   obtain ⟨D, hfg, hD'⟩ := hC.exists_fg_sup_lineal
   rw [← hD']


### PR DESCRIPTION
Removes all transparency overrides. Three proofs needed slight adjustments to continue to compile.

Resolves #61