### PR TITLE
feat: make `lake build` don't throw warnings on `sorry`

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -7,6 +7,7 @@ defaultTargets = ["Polyhedral"]
 pp.unicode.fun = true # pretty-prints `fun a ↦ b`
 autoImplicit = false
 relaxedAutoImplicit = false
+warn.sorry = false
 weak.linter.mathlibStandardSet = true
 maxSynthPendingDepth = 3
 


### PR DESCRIPTION
... since having `sorry` is the normal state of the repo at this point.